### PR TITLE
fix missing error handling and input validation across kamino, ripple, fuel and injective handlers

### DIFF
--- a/chains/fuel.js
+++ b/chains/fuel.js
@@ -13,11 +13,25 @@ function setRoutes(routerPrime) {
   routerPrime.use('/fuel', router)
 
   router.post('/query', async (req, res) => {
-    const { contractId, abi, method, params = [] } = await req.json()
+    try {
+      const { contractId, abi, method, params = [] } = await req.json()
 
-    const contract = new Contract(contractId, abi, await getProvider())
-    const { value } = await contract.functions[method](...params).get()
-    res.json(value)
+      if (!contractId || !abi || !method) {
+        return res.status(400).json({ error: 'contractId, abi and method are required' })
+      }
+
+      const contract = new Contract(contractId, abi, await getProvider())
+
+      if (typeof contract.functions[method] !== 'function') {
+        return res.status(400).json({ error: `method "${method}" does not exist on contract` })
+      }
+
+      const { value } = await contract.functions[method](...params).get()
+      res.json(value)
+    } catch (e) {
+      console.error('[fuel] /query error:', e)
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
 }
 

--- a/chains/injective.js
+++ b/chains/injective.js
@@ -23,22 +23,41 @@ function setRoutes(routerPrime) {
   routerPrime.use('/injective', router)
 
   router.get('/mito-vault/:address', async (req, res) => {
-    const { address } = req.params
-    const response = await getMitoApi().fetchVault({ contractAddress: address })
-    res.json(response)
+    try {
+      const { address } = req.params
+      if (!address) return res.status(400).json({ error: 'address is required' })
+      const response = await getMitoApi().fetchVault({ contractAddress: address })
+      res.json(response)
+    } catch (e) {
+      console.error('[injective] /mito-vault error:', e)
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
+
   router.post('/orderbook/markets', async (req, res) => {
-    const {type = TYPES.SPOT, marketStatus = 'active' } = await req.json()
-    const markets = await getClient(type).fetchMarkets({ marketStatus, })
-    res.json(p2j(markets))
+    try {
+      const { type = TYPES.SPOT, marketStatus = 'active' } = await req.json()
+      const markets = await getClient(type).fetchMarkets({ marketStatus })
+      res.json(p2j(markets))
+    } catch (e) {
+      console.error('[injective] /orderbook/markets error:', e)
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
+
   router.post('/orderbook/orders', async (req, res) => {
-    const {type = TYPES.SPOT, marketIds} = await req.json()
-    const chunks = sliceIntoChunks(marketIds, 20)
-    const response = []
-    for (const chunk of chunks)
-      response.push(...await getClient(type).fetchOrderbooksV2(chunk))
-    res.json(response)
+    try {
+      const { type = TYPES.SPOT, marketIds } = await req.json()
+      if (!Array.isArray(marketIds) || marketIds.length === 0) {
+        return res.status(400).json({ error: 'marketIds must be a non-empty array' })
+      }
+      const chunks = sliceIntoChunks(marketIds, 20)
+      const results = await Promise.all(chunks.map((chunk) => getClient(type).fetchOrderbooksV2(chunk)))
+      res.json(results.flat())
+    } catch (e) {
+      console.error('[injective] /orderbook/orders error:', e)
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
 }
 
@@ -63,8 +82,8 @@ function getClient(type = TYPES.SPOT) {
       clients[type] = new IndexerGrpcSpotApi(network.indexer);
     else if (type === TYPES.DERIVATIVES)
       clients[type] = new IndexerGrpcDerivativesApi(network.indexer)
-    else if(type === TYPES.BANK)
-    clients[type] = new ChainGrpcBankApi(network.grpc)
+    else if (type === TYPES.BANK)
+      clients[type] = new ChainGrpcBankApi(network.grpc)
     else
       throw new Error('Unknown type')
   }

--- a/chains/kamino.js
+++ b/chains/kamino.js
@@ -14,7 +14,6 @@ async function getCachedTvl() {
   if (cachedTvl && cacheTimestamp && (now - cacheTimestamp < cacheDuration))
     return cachedTvl
 
-
   cachedTvl = getTvl()
   cacheTimestamp = now
   return cachedTvl
@@ -29,7 +28,7 @@ async function getCachedTvl() {
 
 async function getKaminoLendMarketReserves(market) {
   market = new PublicKey(market)
-  const  reserves  = await getReservesForMarket(market, getConnection(), PROGRAM_ID)
+  const reserves = await getReservesForMarket(market, getConnection(), PROGRAM_ID)
   return [...reserves].map(([_, i]) => ({
     token: i.state.collateral.mintPubkey.toString(),
     price: Number(i.tokenOraclePrice.price),
@@ -51,12 +50,23 @@ function setRoutes(routerPrime) {
   routerPrime.use('/kamino', router)
 
   router.get('/tvl', async (_req, res) => {
-    res.json(await getCachedTvl())
+    try {
+      res.json(await getCachedTvl())
+    } catch (e) {
+      console.error('[kamino] /tvl error:', e)
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
 
   router.get('/lend/:market', async (req, res) => {
-    const { market } = req.params
-    res.json(await getKaminoLendMarketReserves(market))
+    try {
+      const { market } = req.params
+      if (!market) return res.status(400).json({ error: 'market is required' })
+      res.json(await getKaminoLendMarketReserves(market))
+    } catch (e) {
+      console.error('[kamino] /lend error:', e)
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
 }
 

--- a/chains/ripple.js
+++ b/chains/ripple.js
@@ -1,25 +1,41 @@
 const HyperExpress = require('hyper-express')
 const xrpl = require("xrpl");
 
+let client = null
+
+async function getClient() {
+  if (!client || !client.isConnected()) {
+    client = new xrpl.Client('wss://xrplcluster.com/')
+    await client.connect()
+  }
+  return client
+}
+
 function setRoutes(routerPrime) {
   const router = new HyperExpress.Router()
 
   routerPrime.use('/ripple', router)
 
   router.post('/gateway_balances', async (req, res) => {
-    const { account, hotwallet } = await req.json()
-    const client = new xrpl.Client('wss://xrplcluster.com/');
-    await client.connect();
-  
-    const issuerAccountInfo = await client.request({
-      command: 'gateway_balances',
-      account,
-      hotwallet: [hotwallet],
-    });
-  
-    client.disconnect();
+    try {
+      const { account, hotwallet } = await req.json()
+      if (!account || !hotwallet) {
+        return res.status(400).json({ error: 'account and hotwallet are required' })
+      }
 
-    res.json(issuerAccountInfo.result)
+      const xrplClient = await getClient()
+      const issuerAccountInfo = await xrplClient.request({
+        command: 'gateway_balances',
+        account,
+        hotwallet: [hotwallet],
+      })
+
+      res.json(issuerAccountInfo.result)
+    } catch (e) {
+      console.error('[ripple] /gateway_balances error:', e)
+      client = null // reset on error so next request reconnects
+      res.status(500).json({ error: 'Internal server error' })
+    }
   })
 }
 


### PR DESCRIPTION
all four handlers had unhandled exceptions - any bad input or RPC failure would throw with no response sent to the caller, i placed these fixes in place:

kamino: added try/catch on both routes and a 400 check for missing market param
ripple: added try/catch, 400 check for missing fields, and replaced per-request WebSocket connect/disconnect with a persistent reused client that reconnects only when needed
fuel: added try/catch, 400 checks for missing fields, and an explicit check that the requested method exists on the contract before calling it
injective: added try/catch on all three routes, 400 validation on marketIds, and replaced the sequential for loop in /orderbook/orders with Promise.all